### PR TITLE
Resolve dependabot alerts

### DIFF
--- a/db/requirements.txt
+++ b/db/requirements.txt
@@ -10,7 +10,7 @@ Flask==1.1.2
 idna==2.10
 isort==4.3.21
 itsdangerous==1.1.0
-Jinja2==2.11.2
+jinja2>=2.11.3
 jmespath==0.10.0
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
@@ -22,7 +22,7 @@ s3transfer==0.3.3
 simplejson==3.17.2
 six==1.15.0
 toml==0.10.1
-urllib3==1.25.10
+urllib3>=1.26.5
 Werkzeug==1.0.1
 wrapt==1.12.1
 simplejson==3.17.2

--- a/loader/requirements.txt
+++ b/loader/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.24.0
-urllib3==1.25.10
+urllib3>=1.26.5

--- a/s1/requirements.txt
+++ b/s1/requirements.txt
@@ -7,7 +7,7 @@ Flask==1.1.2
 idna==2.10
 isort==4.3.21
 itsdangerous==1.1.0
-Jinja2==2.11.2
+jinja2>=2.11.3
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
 mccabe==0.6.1
@@ -16,7 +16,7 @@ requests==2.24.0
 simplejson==3.17.2
 six==1.15.0
 toml==0.10.1
-urllib3==1.25.10
+urllib3>=1.26.5
 Werkzeug==1.0.1
 wrapt==1.12.1
 PyJWT==1.7.1

--- a/s2/standalone/requirements.txt
+++ b/s2/standalone/requirements.txt
@@ -7,7 +7,7 @@ Flask==1.1.2
 idna==2.10
 isort==4.3.21
 itsdangerous==1.1.0
-Jinja2==2.11.2
+jinja2>=2.11.3
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
 mccabe==0.6.1
@@ -16,7 +16,7 @@ requests==2.24.0
 simplejson==3.17.2
 six==1.15.0
 toml==0.10.1
-urllib3==1.25.10
+urllib3>=1.26.5
 Werkzeug==1.0.1
 wrapt==1.12.1
 prometheus-flask-exporter==0.18.1

--- a/s2/v1.1/requirements.txt
+++ b/s2/v1.1/requirements.txt
@@ -7,7 +7,7 @@ Flask==1.1.2
 idna==2.10
 isort==4.3.21
 itsdangerous==1.1.0
-Jinja2==2.11.2
+jinja2>=2.11.3
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
 mccabe==0.6.1
@@ -16,7 +16,7 @@ requests==2.24.0
 simplejson==3.17.2
 six==1.15.0
 toml==0.10.1
-urllib3==1.25.10
+urllib3>=1.26.5
 Werkzeug==1.0.1
 wrapt==1.12.1
 prometheus-flask-exporter==0.18.1

--- a/s2/v1/requirements.txt
+++ b/s2/v1/requirements.txt
@@ -7,7 +7,7 @@ Flask==1.1.2
 idna==2.10
 isort==4.3.21
 itsdangerous==1.1.0
-Jinja2==2.11.2
+jinja2>=2.11.3
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
 mccabe==0.6.1
@@ -16,7 +16,7 @@ requests==2.24.0
 simplejson==3.17.2
 six==1.15.0
 toml==0.10.1
-urllib3==1.25.10
+urllib3>=1.26.5
 Werkzeug==1.0.1
 wrapt==1.12.1
 prometheus-flask-exporter==0.18.1

--- a/s2/v2/requirements.txt
+++ b/s2/v2/requirements.txt
@@ -7,7 +7,7 @@ Flask==1.1.2
 idna==2.10
 isort==4.3.21
 itsdangerous==1.1.0
-Jinja2==2.11.2
+jinja2>=2.11.3
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
 mccabe==0.6.1
@@ -16,7 +16,7 @@ requests==2.24.0
 simplejson==3.17.2
 six==1.15.0
 toml==0.10.1
-urllib3==1.25.10
+urllib3>=1.26.5
 Werkzeug==1.0.1
 wrapt==1.12.1
 prometheus-flask-exporter==0.18.1


### PR DESCRIPTION
Resolve dependabot alerts due to outdated jinja2 and urllib3 packages.